### PR TITLE
[FIX] Updated to new Pyscript version and using a .toml file

### DIFF
--- a/pyscript-units-conv.toml
+++ b/pyscript-units-conv.toml
@@ -1,0 +1,3 @@
+packages = ["pyodide-http", "pyudunits2", "lxml"]
+from = "test_unit.py"
+

--- a/test_unit.py
+++ b/test_unit.py
@@ -1,14 +1,25 @@
+from pyscript import document
 from pyudunits2 import UnitSystem, Converter
-import numpy as np
 
-# Coversion
 def run_conversion(input_unit, output_unit, val):
     ut_system = UnitSystem.from_udunits2_xml()
-    in_u= ut_system.unit(input_unit)
+    in_u = ut_system.unit(input_unit)
     out_u = ut_system.unit(output_unit)
     converter = Converter(in_u, out_u)
-    expression = converter.expression
-    
     output_val = converter.convert(float(val))
-    return output_val, expression
+    return output_val, converter.expression
+
+def convert_value():
+    input_val = float(document.getElementById("input_value").value)
+    input_unit = document.getElementById("input_unit").value
+    output_unit = document.getElementById("output_unit").value
+
+    try:
+        converted, expression = run_conversion(input_unit, output_unit, input_val)
+        document.getElementById("result").innerText = f"{input_val} {input_unit} = {converted} {output_unit}"
+        document.getElementById("equation").innerText = expression
+    except Exception as e:
+        document.getElementById("result").innerText = f"Error: {e}"
+        document.getElementById("equation").innerText = ""
+
 

--- a/unitconverter.html
+++ b/unitconverter.html
@@ -3,35 +3,10 @@
   <meta charset="UTF-8">
   <title>PyScript Example</title>
 
-  <!-- PyScript CSS and JS -->
-  <link rel="stylesheet" href="https://pyscript.net/releases/2023.05.1/pyscript.css" />
-  <script defer src="https://pyscript.net/releases/2023.05.1/pyscript.js"></script>
-
-
-  <!-- Bootstrap and Plotly -->
+  <!-- PyScript and Bootstrap -->
+  <link rel="stylesheet" href="https://pyscript.net/releases/2025.3.1/core.css">
+  <script type="module" src="https://pyscript.net/releases/2025.3.1/core.js"></script>
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css">
-  <script src="https://cdn.plot.ly/plotly-3.0.0.min.js"></script>
-
-
-  <!-- PyScript Config -->
-  <py-config>
-    packages = [
-      "pyudunits2[xml]",
-      "numpy"
-    ]
-
-    [[fetch]]
-    from = "./"
-    files = ["test_unit.py"]
-
-    [splashscreen]
-    autoclose = true
-
-    [[runtimes]]
-    src = "https://cdn.jsdelivr.net/pyodide/v0.22.0/full/pyodide.js"
-    name = "pyodide-0.22.0"
-    lang = "python"
-  </py-config>
 
 <body>
     <div class="jumbotron">
@@ -44,36 +19,26 @@
 <!-- Row 1: Input Unit + Value Input + Convert Button -->
 <div class="row">
         <div class="col-sm-2 p-2 ml-4 mb-1">
-            <button type="button" class="btn btn-secondary">Select input units from list:</button>
+            <button type="button" class="btn btn-secondary">Type input units</button>
         </div>
     <div class="col-sm-3 p-2">
-        <select class="form-control" id="input_unit">
-            <option value="meter">Meter</option>
-            <option value="kilometer">Kilometer</option>
-            <option value="foot">Foot</option>
-            <option value="mile">Mile</option>
-        </select>
+        <input type="text" class="form-control" id="input_unit" placeholder="Enter units">
     </div>
     <div class="col-sm-3 p-2">
         <input type="number" class="form-control" id="input_value" placeholder="Enter number">
     </div>
     <div class="col-sm-2 p-2">
-        <button class="btn btn-primary" py-click="convert_value()">Convert</button>
+        <button class="btn btn-primary" py-click="convert_value">Convert</button>
     </div>
 </div>
 
-<!-- Row 2: Output Unit + Result Display -->
+<!-- Row 2: Output Unit + Result Display and equation or error is dispayed-->
 <div class="row">
         <div class="col-sm-2 p-2 ml-4 mb-1">
-            <button type="button" class="btn btn-secondary">Select output units from list:</button>
+            <button type="button" class="btn btn-secondary">Type output units </button>
         </div>
     <div class="col-sm-3 p-2">
-        <select class="form-control" id="output_unit">
-            <option value="m">Meter</option>
-            <option value="km">Kilometer</option>
-            <option value="ft">Foot</option>
-            <option value="mile">Mile</option>
-        </select>
+        <input type="text" class="form-control" id="output_unit" placeholder="Enter units">
     </div>
     <div class="col-sm-5 p-2">
         <p id="result" class="mb-0 font-italic">Result will appear here</p>
@@ -81,26 +46,6 @@
     </div>
 </div>
 
-<py-script>
-from test_unit import run_conversion
-
-def convert_value():
-    # Get values from HTML
-    input_val = Element("input_value").element.value
-    input_unit = Element("input_unit").element.value
-    output_unit = Element("output_unit").element.value
-
-    try:
-        # Call your real conversion function
-        converted, expression = run_conversion( input_unit, output_unit,input_val)
-
-        # Display result
-        Element("result").element.innerText = f"{input_val} {input_unit} = {converted} {output_unit}"
-        Element("equation").element.innerText = f"{expression}"
-    except Exception as e:
-        Element("result").element.innerText = f"Error: {e}"
-        Element("equation").element.innerText = ""
-</py-script>
-
-
+<script type="py" src="test_unit.py" config="pyscript-units-conv.toml"></script>
+<body>
 </html>


### PR DESCRIPTION
- I updated to pyscript 2025
- No pyconfig in the html but we use a toml file instead
- No code in the html file but only one `<script> </script>` sentence and all is in a separate .py code
- No drop down selection but the user types the units
  - In case the input is non existing units, the error message is printed and will say something like this:
`Error: Unable to convert the identifier _'wrong units'_ into a unit in the unit system`